### PR TITLE
syntax: strings: Only skip over known escapes

### DIFF
--- a/syntax/fish.vim
+++ b/syntax/fish.vim
@@ -64,8 +64,8 @@ syntax match fishSingleQuoteEscape /\\[\\']/ contained
 syntax match fishDoubleQuoteEscape /\\[\\"$\n]/ contained
 syntax cluster fishStringEscape contains=fishSingleQuoteEscape,fishDoubleQuoteEscape
 
-syntax region fishString start=/'/ skip=/\v(\\{2})|(\\)'/ end=/'/ contains=fishSingleQuoteEscape,@Spell
-syntax region fishString start=/"/ skip=/\v(\\{2})|(\\)"/ end=/"/ contains=fishDoubleQuoteEscape,fishDeref,fishDerefExtension,@Spell
+syntax region fishString start=/'/ skip=/\\[\\']/ end=/'/ contains=fishSingleQuoteEscape,@Spell
+syntax region fishString start=/"/ skip=/\\[\\"$\n]/ end=/"/ contains=fishDoubleQuoteEscape,fishDeref,fishDerefExtension,@Spell
 syntax match fishCharacter /\v\\[0abefnrtv *?~%#(){}\[\]<>&;"']|\\[xX][0-9a-f]{1,2}|\\o[0-7]{1,2}|\\u[0-9a-f]{1,4}|\\U[0-9a-f]{1,8}|\\c[a-z]/
 syntax match fishCharacter /\v\\e[a-zA-Z0-9]/
 


### PR DESCRIPTION
Fish has a very small set of escapes that are recognized in either single or double quoted strings.  Skipping more could only produce incorrect parsing.